### PR TITLE
Feedback (minor issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ console.log(
 hyperprint(value, options);
 ```
 
-- `indent: string = '   '` Indent unit to use. Defaults to 4 spaces.
+- `prettier: Object = { semi: false, singleQuote: true, tabWidth: 4 }`
+  Prettier config to use when formatting the output JSX.
 
 # Test
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "git://github.com/GitbookIO/slate-hyperprint.git",
   "main": "./dist/index.js",
   "dependencies": {
-    "indent-string": "^3.2.0"
+    "indent-string": "^3.2.0",
+    "prettier": "1.9.2"
   },
   "peerDependencies": {
     "slate": "*"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "indent-string": "^3.2.0",
-    "prettier": "1.9.2",
     "js-yaml": "^3.10.0",
-    "meow": "^4.0.0"
+    "meow": "^4.0.0",
+    "prettier": "1.7.0"
   },
   "peerDependencies": {
     "slate": "*"
@@ -30,6 +30,7 @@
     "eslint": "^4.10.0",
     "eslint-config-gitbook": "^2.0.3",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-prettier": "^2.4.0",
     "expect": "^1.20.2",
     "flow-bin": "^0.57.3",
     "gh-pages": "^1.0.0",

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -22,5 +22,6 @@ if (input.length > 0) {
         json;
     const state = Slate.Value.create({ document });
 
+    // eslint-disable-next-line no-console
     console.log(hyperprint(state.document));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,42 @@
 /* @flow */
 
+import prettier from 'prettier';
+
 import parse from './parse';
 import type { Options } from './options';
 import type { SlateModel } from './types';
 
-function hyperprint(model: SlateModel, { indent = '    ' }: Options = {}) {
+const DEFAULT_OPTIONS: Options = {
+    indent: '    ',
+    prettier: {
+        semi: false,
+        singleQuote: true,
+        tabWidth: 4
+    }
+};
+
+function hyperprint(
+    model: SlateModel,
+    optionsParam: Options = DEFAULT_OPTIONS
+) {
     if (!model) {
         throw new Error('slate-hyperprint: Expected a Slate model');
     }
 
     const options = {
-        indent
+        ...DEFAULT_OPTIONS,
+        ...optionsParam
     };
 
-    return parse(model, options)
+    const printed = parse(model, options)
         .map(tag => tag.print(options))
         .join('\n');
+
+    const formatted = prettier.format(printed, options.prettier);
+
+    const noSemi = formatted.trim().replace(/^;/, '');
+
+    return noSemi;
 }
 
 export default hyperprint;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import type { Options } from './options';
 import type { SlateModel } from './types';
 
 const DEFAULT_OPTIONS: Options = {
-    indent: '    ',
     prettier: {
         semi: false,
         singleQuote: true,

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,8 @@
 /* @flow */
 
-export type Options = {|
+export type Options = {
     // String for one level of indentation
-    indent: string
-|};
+    indent: string,
+    // Prettier config to use
+    prettier: Object
+};

--- a/src/options.js
+++ b/src/options.js
@@ -1,8 +1,6 @@
 /* @flow */
 
 export type Options = {
-    // String for one level of indentation
-    indent: string,
     // Prettier config to use
     prettier: Object
 };

--- a/src/parse.js
+++ b/src/parse.js
@@ -28,18 +28,18 @@ const PARSERS = {
         Tag.create({
             name: block.type,
             attributes: block.data.toJSON(),
-            children: block.nodes
-                .flatMap(node => parse(node, options))
-                .toArray()
+            children: block.isVoid
+                ? []
+                : block.nodes.flatMap(node => parse(node, options)).toArray()
         })
     ],
     inline: (inline, options) => [
         Tag.create({
             name: inline.type,
             attributes: inline.data.toJSON(),
-            children: inline.nodes
-                .flatMap(node => parse(node, options))
-                .toArray()
+            children: inline.isVoid
+                ? []
+                : inline.nodes.flatMap(node => parse(node, options)).toArray()
         })
     ],
     text: (text, options) => {

--- a/src/tag.js
+++ b/src/tag.js
@@ -33,7 +33,6 @@ class Tag {
     // Print this tag
     print(options: Options): string {
         const { name, children, attributes } = this;
-        const { indent } = options;
 
         const stringifiedAttrs = Object.keys(attributes).map(key => {
             const value = attributes[key];
@@ -57,7 +56,7 @@ class Tag {
 
         return [
             `<${openingTagInner}>`,
-            indentString(printedChildren.join('\n'), 1, { indent }),
+            indentString(printedChildren.join('\n'), 1, { indent: '    ' }),
             `</${name}>`
         ].join('\n');
     }

--- a/tests/fixtures/code-example.js
+++ b/tests/fixtures/code-example.js
@@ -5,18 +5,17 @@ import h from '../h';
 const input = (
     <value>
         <document>
-            <heading>{'Slate + Code Highlighting'}</heading>
+            <heading>Slate + Code Highlighting</heading>
             <paragraph>
-                {
-                    'This page is a basic example of Slate + slate-prism + slate-edit-code plugins:'
-                }
+                This page is a basic example of Slate + slate-prism +
+                slate-edit-code plugins:
             </paragraph>
             <code_block syntax="javascript">
                 <code_line>{'// Some javascript'}</code_line>
                 <code_line>{"var msg = 'Hello world';"}</code_line>
             </code_block>
 
-            <paragraph>{'Syntax can be set on a per-block basis:'}</paragraph>
+            <paragraph>Syntax can be set on a per-block basis:</paragraph>
             <code_block syntax="html">
                 <code_line>{'<!-- Some HTML -->'}</code_line>
                 <code_line>{'<b>Hello World</b>'}</code_line>
@@ -28,30 +27,19 @@ const input = (
 const output = `
 <value>
     <document>
-        <heading>
-            Slate + Code Highlighting
-        </heading>
+        <heading>Slate + Code Highlighting</heading>
         <paragraph>
-            This page is a basic example of Slate + slate-prism + slate-edit-code plugins:
+            This page is a basic example of Slate + slate-prism +
+            slate-edit-code plugins:
         </paragraph>
         <code_block syntax="javascript">
-            <code_line>
-                // Some javascript
-            </code_line>
-            <code_line>
-                {'var msg = \\'Hello world\\';'}
-            </code_line>
+            <code_line>// Some javascript</code_line>
+            <code_line>{"var msg = 'Hello world';"}</code_line>
         </code_block>
-        <paragraph>
-            Syntax can be set on a per-block basis:
-        </paragraph>
+        <paragraph>Syntax can be set on a per-block basis:</paragraph>
         <code_block syntax="html">
-            <code_line>
-                {'<!-- Some HTML -->'}
-            </code_line>
-            <code_line>
-                {'<b>Hello World</b>'}
-            </code_line>
+            <code_line>{'<!-- Some HTML -->'}</code_line>
+            <code_line>{'<b>Hello World</b>'}</code_line>
         </code_block>
     </document>
 </value>

--- a/tests/fixtures/empty-nodes.js
+++ b/tests/fixtures/empty-nodes.js
@@ -16,9 +16,7 @@ const output = `
 <value>
     <document>
         <paragraph />
-        <paragraph>
-            {' '}
-        </paragraph>
+        <paragraph> </paragraph>
     </document>
 </value>
 `;

--- a/tests/fixtures/marks.js
+++ b/tests/fixtures/marks.js
@@ -20,21 +20,11 @@ const output = `
 <value>
     <document>
         <paragraph>
+            <bold>Hello</bold> I am <bold>using bold </bold>
             <bold>
-                Hello
+                <italic> and italic</italic>
             </bold>
-            {' '}I am{' '}
-            <bold>
-                using bold{' '}
-            </bold>
-            <bold>
-                <italic>
-                    {' '}and italic
-                </italic>
-            </bold>
-            <italic>
-                {' '}and just italic
-            </italic>
+            <italic> and just italic</italic>
             .
         </paragraph>
     </document>

--- a/tests/fixtures/short-text.js
+++ b/tests/fixtures/short-text.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../h';
+
+const input = (
+    <value>
+        <document>
+            <paragraph>Short text.</paragraph>
+        </document>
+    </value>
+);
+
+const output = `
+<value>
+    <document>
+        <paragraph>Short text.</paragraph>
+    </document>
+</value>
+`;
+
+export { input, output };

--- a/tests/fixtures/text-escaping.js
+++ b/tests/fixtures/text-escaping.js
@@ -18,18 +18,10 @@ const input = (
 const output = `
 <value>
     <document>
-        <paragraph>
-            Should not escape simple text.
-        </paragraph>
-        <paragraph>
-            {'Should escape \\' properly'}
-        </paragraph>
-        <paragraph>
-            {'Should escape <, >, {, } properly'}
-        </paragraph>
-        <paragraph>
-            {' '}
-        </paragraph>
+        <paragraph>Should not escape simple text.</paragraph>
+        <paragraph>{"Should escape ' properly"}</paragraph>
+        <paragraph>{'Should escape <, >, {, } properly'}</paragraph>
+        <paragraph> </paragraph>
     </document>
 </value>
 `;

--- a/tests/fixtures/void.js
+++ b/tests/fixtures/void.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../h';
+
+const input = (
+    <value>
+        <document>
+            <block type="embed" isVoid />
+        </document>
+    </value>
+);
+
+const output = `
+<value>
+    <document>
+        <embed />
+    </document>
+</value>
+`;
+
+export { input, output };

--- a/tests/fixtures/void.js
+++ b/tests/fixtures/void.js
@@ -5,7 +5,10 @@ import h from '../h';
 const input = (
     <value>
         <document>
-            <block type="embed" isVoid />
+            <paragraph>
+                <inline type="link" isVoid />
+            </paragraph>
+            <block type="image" isVoid data={{ src: 'image.png' }} />
         </document>
     </value>
 );
@@ -13,7 +16,10 @@ const input = (
 const output = `
 <value>
     <document>
-        <embed />
+        <paragraph>
+            <link />
+        </paragraph>
+        <image src="image.png" />
     </document>
 </value>
 `;

--- a/website/main.js
+++ b/website/main.js
@@ -26,6 +26,7 @@ class Website extends React.Component<*, *> {
         try {
             value = Slate.Value.fromJSON(JSON.parse(input));
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.log(e);
             value = Slate.Value.create();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,6 +3265,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
+
 prettier@^1.7.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.1.tgz#91064d778c08c85ac1cbe6b23195c34310d039f9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,13 @@ eslint-plugin-prettier@^2.3.1:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-plugin-prettier@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz#85cab0775c6d5e3344ef01e78d960f166fb93aae"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-plugin-react@^7.3.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz#300a95861b9729c087d362dd64abcc351a74364a"
@@ -3368,9 +3375,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
+prettier@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
 
 prettier@^1.7.0:
   version "1.8.1"


### PR DESCRIPTION
So I've been using `slate-hyperprint` intensively and eventually found two minor issues:

* Void nodes are not printed as auto-closing tags due to their inner `" "`
* Nodes are printed on multiple lines even if their content is short enough

The first one is probably not too hard to fix. For the second I used prettier which does an awesome job. Maybe `slate-hyperprint` could use it behind the scene to print a well-formatted jsx. I have no idea what prettier-as-a-library expects as input.

This PR is not really meant to be merged, just thought I'd share two failing tests for illustration.