### PR TITLE
Escape line breaks

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,10 @@ function escape(s: string): string {
         return s;
     }
 
-    return `{'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'}`;
+    return `{'${s
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\n/g, '\\n')}'}`;
 }
 
 function printString(s: string) {

--- a/tests/fixtures/line-break.js
+++ b/tests/fixtures/line-break.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+import h from '../h';
+
+const input = (
+    <value>
+        <document>
+            <paragraph>
+                {
+                    "This is a slate-hyperprint's test for strings with\n\nline breaks."
+                }
+            </paragraph>
+        </document>
+    </value>
+);
+
+const output = `
+<value>
+    <document>
+        <paragraph>
+            {
+                "This is a slate-hyperprint's test for strings with\\n\\nline breaks."
+            }
+        </paragraph>
+    </document>
+</value>
+`;
+
+export { input, output };


### PR DESCRIPTION
The error below is thrown when a string contains line breaks:

```
SyntaxError: Unterminated string constant (4:14)
  2 |     <document>
  3 |         <paragraph>
> 4 |             {'This is a slate-hyperprint\'s test for strings with
    |              ^
  5 | 
  6 |             line breaks.'}
  7 |         </paragraph>
```

This PR escapes them so they're properly printed as `\n`.