### PR TITLE
Fix line break escaping detection

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,9 @@
 // @flow
 
-const jsxStopChars = ['<', '>', '{', '}', "'", '"', '\n'];
+const charsToEscape = ['<', '>', '{', '}', "'", '"', '\n'];
 
 function shouldBeEscaped(s: string): boolean {
-    return jsxStopChars.some(jsxStopChar => s.includes(jsxStopChar));
+    return charsToEscape.some(char => s.includes(char));
 }
 
 function preserveTrailingSpace(s: string): string {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 // @flow
 
-const jsxStopChars = ['<', '>', '{', '}', "'", '"'];
+const jsxStopChars = ['<', '>', '{', '}', "'", '"', '\n'];
 
 function shouldBeEscaped(s: string): boolean {
     return jsxStopChars.some(jsxStopChar => s.includes(jsxStopChar));

--- a/tests/fixtures/text-escaping.js
+++ b/tests/fixtures/text-escaping.js
@@ -16,7 +16,10 @@ const input = (
             <paragraph
                 should={{ escape: {}, object: ['etc.'], always: new Date(0) }}
             />
-            <paragraph>{"Should escape'em \n\nline breaks."}</paragraph>
+            <paragraph>
+                <bold>{"Should escape'em \n\nline breaks."}</bold>
+                {'\n'}
+            </paragraph>
         </document>
     </value>
 );
@@ -37,7 +40,10 @@ const output = `
                 object: ['etc.']
             }}
         />
-        <paragraph>{"Should escape'em \\n\\nline breaks."}</paragraph>
+        <paragraph>
+            <bold>{"Should escape'em \\n\\nline breaks."}</bold>
+            {'\\n'}
+        </paragraph>
     </document>
 </value>
 `;


### PR DESCRIPTION
Line breaks weren't escaped when they were part of a string that doesn't contain other characters to escape 🤐 

I tweaked the test case to reproduce the bug and fixed it 👌 