### PR TITLE
Fix printing data with keys that are not valid JSX attributes (e. g. numbers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha": "^3.0.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "slate": "^0.33.3",
+    "slate": "^0.34.7",
     "slate-hyperscript": "^0.5.9",
     "slate-react": "^0.12.3"
   },

--- a/src/parse.js
+++ b/src/parse.js
@@ -108,17 +108,31 @@ function getAttributes(
     // False to keep it under `data` and to make `type` explicit
     asShorthand: boolean = true
 ): Object {
-    return {
-        // type
-        ...(!asShorthand && model.type ? { type: model.type } : {}),
-        // key
-        ...(options.preserveKeys && model.key ? { key: model.key } : {}),
-        // data
-        ...(!asShorthand && !model.data.isEmpty()
-            ? { data: model.data.toJSON() }
-            : model.data.toJSON()),
-        ...(!asShorthand && model.isVoid ? { isVoid: true } : {})
-    };
+    let result = {};
+
+    // type
+    if (!asShorthand && model.type) {
+        result.type = model.type;
+    }
+
+    // key
+    if (options.preserveKeys && model.key) {
+        result.key = model.key;
+    }
+
+    // data
+    if (!asShorthand && !model.data.isEmpty()) {
+        result.data = model.data.toJSON();
+    } else {
+        result = { ...result, ...model.data.toJSON() };
+    }
+
+    // isVoid
+    if (!asShorthand && model.isVoid) {
+        result.isVoid = true;
+    }
+
+    return result;
 }
 
 /*

--- a/src/parse.js
+++ b/src/parse.js
@@ -18,7 +18,12 @@ const PARSERS = {
     document: (document, options) => [
         Tag.create({
             name: 'document',
-            attributes: getAttributes(document, options),
+            attributes: {
+                ...(options.preserveKeys ? { key: document.key } : {}),
+                ...(document.data.isEmpty()
+                    ? {}
+                    : { data: document.data.toJSON() })
+            },
             children: document.nodes
                 .flatMap(node => parse(node, options))
                 .toArray()
@@ -87,7 +92,7 @@ const PARSERS = {
 };
 
 /*
- * Returns attributes (with or without k)
+ * Returns attributes (with or without key)
  */
 function getAttributes(model: SlateModel, options: Options): Object {
     return {

--- a/src/parse.js
+++ b/src/parse.js
@@ -124,6 +124,7 @@ function getAttributes(
     if (!asShorthand && !model.data.isEmpty()) {
         result.data = model.data.toJSON();
     } else {
+        // Spread the data as individual attributes
         result = { ...result, ...model.data.toJSON() };
     }
 

--- a/tests/fixtures/document-data.js
+++ b/tests/fixtures/document-data.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import h from '../h';
+
+const input = (
+    <value>
+        <document data={{ key: 'value' }}>
+            <paragraph>Hello</paragraph>
+        </document>
+    </value>
+);
+
+const output = `
+<value>
+    <document data={{ key: 'value' }}>
+        <paragraph>Hello</paragraph>
+    </document>
+</value>
+`;
+
+export { input, output };

--- a/tests/fixtures/number-as-data-key.js
+++ b/tests/fixtures/number-as-data-key.js
@@ -1,0 +1,25 @@
+/** @jsx h */
+
+import h from '../h';
+
+const options = {
+    preserveKeys: true
+};
+
+const input = (
+    <value>
+        <document>
+            <block type="image" isVoid data={{ 0: 'foo' }} />
+        </document>
+    </value>
+);
+
+const output = `
+<value>
+    <document key="5">
+        <block type="image" isVoid data={{ 0: 'foo' }} />
+    </document>
+</value>
+`;
+
+export { input, output, options };

--- a/tests/fixtures/number-as-data-key.js
+++ b/tests/fixtures/number-as-data-key.js
@@ -2,10 +2,6 @@
 
 import h from '../h';
 
-const options = {
-    preserveKeys: true
-};
-
 const input = (
     <value>
         <document>
@@ -16,10 +12,10 @@ const input = (
 
 const output = `
 <value>
-    <document key="5">
-        <block type="image" isVoid data={{ 0: 'foo' }} />
+    <document>
+        <block data={{ '0': 'foo' }} isVoid type="image" />
     </document>
 </value>
 `;
 
-export { input, output, options };
+export { input, output };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,7 +1487,7 @@ debug@^2.2.0, debug@^2.3.2, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -3869,22 +3869,22 @@ slate-react@^0.12.3:
     slate-plain-serializer "^0.5.9"
     slate-prop-types "^0.4.26"
 
-slate-schema-violations@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.7.tgz#cf2c6156eaf545f4d1985d3d1b94c50d6d273a08"
+slate-schema-violations@^0.1.20:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.39.tgz#854ab5624136419cef4c803b1823acabe11f1c15"
 
-slate@^0.33.3:
-  version "0.33.3"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.33.3.tgz#e9eb2f7c2740a46d45eb7b60c1f4da6699285878"
+slate@^0.34.7:
+  version "0.34.7"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.34.7.tgz#5908e1d0fc092a2212488beca65671f01e0eb80a"
   dependencies:
-    debug "^2.3.2"
+    debug "^3.1.0"
     direction "^0.1.5"
     esrever "^0.2.0"
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
     slate-dev-logger "^0.1.39"
-    slate-schema-violations "^0.1.7"
+    slate-schema-violations "^0.1.20"
     type-of "^2.0.1"
 
 slice-ansi@1.0.0:


### PR DESCRIPTION
Invalid JSX:

```js
    <value>
        <document>
            <image 0="foo" />
        </document>
    </value>
```

Valid alternative:

```js
    <value>
        <document>
            <block type="image" isVoid data={{ 0: 'foo' }} />
        </document>
    </value>
```

Also fixes printing of data in `document`. In slate hyperscript, you cannot write:

```js
<document someData="value">
```

You must write

```js
<document data={{ someData: 'value' }}>
```
