### PR TITLE
Standalone prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "indent-string": "^3.2.0",
     "is-plain-object": "^2.0.4",
-    "js-yaml": "^3.10.0",
-    "meow": "^4.0.0",
-    "prettier": "1.6.1",
+    "js-yaml": "^3.12.0",
+    "meow": "^5.0.0",
+    "prettier": "1.13.6",
     "stringify-object": "^3.2.2"
   },
   "peerDependencies": {
@@ -51,7 +51,7 @@
     "lint": "eslint ./src ./website",
     "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --reporter=list",
     "build-website": "browserify ./website/main.js -o ./website/bundle.js -t [ babelify --presets [ es2015 react stage-0 ] ]",
-    "serve-website": "http-server ./website/ -p 8080",
+    "serve-website": "http-server ./website/ -p 8090",
     "start": "npm run build-website; npm run serve-website",
     "deploy-website": "npm run build-website; gh-pages -d ./website"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint ./src ./website",
     "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --reporter=list",
     "build-website": "browserify ./website/main.js -o ./website/bundle.js -t [ babelify --presets [ es2015 react stage-0 ] ]",
-    "serve-website": "http-server ./website/ -p 8090",
+    "serve-website": "http-server ./website/ -p 8080",
     "start": "npm run build-website; npm run serve-website",
     "deploy-website": "npm run build-website; gh-pages -d ./website"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import prettier from 'prettier';
+import prettier from 'prettier/standalone';
+import babylon from 'prettier/parser-babylon';
 
 import parse from './parse';
 import type { Options } from './options';
@@ -33,7 +34,11 @@ function hyperprint(
         .map(tag => tag.print(options))
         .join('\n');
 
-    const formatted = prettier.format(printed, options.prettier);
+    const formatted = prettier.format(printed, {
+        ...options.prettier,
+      parser: 'babylon',
+      plugins: [babylon]
+    });
 
     const noSemi = formatted.trim().replace(/^;/, '');
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,8 @@ function hyperprint(
 
     const formatted = prettier.format(printed, {
         ...options.prettier,
-      parser: 'babylon',
-      plugins: [babylon]
+        parser: 'babylon',
+        plugins: [babylon]
     });
 
     const noSemi = formatted.trim().replace(/^;/, '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,7 +2687,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.9.1:
+js-yaml@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2939,19 +2946,19 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-meow@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.0.tgz#fd5855dd008db5b92c552082db1c307cba20b29d"
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
   dependencies:
     camelcase-keys "^4.0.0"
     decamelize-keys "^1.0.0"
     loud-rejection "^1.0.0"
-    minimist "^1.1.3"
     minimist-options "^3.0.1"
     normalize-package-data "^2.3.4"
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -3021,7 +3028,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3391,9 +3398,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+prettier@1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.6.tgz#00ae0b777ad92f81a9e7a1df2f0470b6dab0cb44"
 
 prettier@^1.7.0:
   version "1.8.1"
@@ -4301,3 +4308,9 @@ xtend@^4.0.0, xtend@~4.0.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"


### PR DESCRIPTION
Hi!
I'm experiencing the following issue with prettier@1.6.1 in my project using webpack@4+typescript@2.8.3+slate-hyperscript@2.2.5

`./node_modules/prettier/parser-typescript.js
Module not found: Can't resolve 'module' in '/app/node_modules/prettier'`

Starting from 1.13.0, prettier ships with standalone version, which can be used in browser environment, so I decided to update prettier version.

This PR updates prettier to version 1.13.6 which isn't the latest version of prettier, because starting from 1.13.7 prettier has another [unresolved](https://github.com/prettier/prettier/issues/4959) issue while using with webpack.

Also PR updates all other dependencies.